### PR TITLE
Mark time consuming C++ methods as blocking to allow parallel processing

### DIFF
--- a/lib/tesseract/c/baseapi.rb
+++ b/lib/tesseract/c/baseapi.rb
@@ -188,13 +188,13 @@ module BaseAPI
 			bool process_pages (TessBaseAPI* api, const char* filename, STRING* output) {
 				return api->ProcessPages(filename, NULL, 0, output);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			bool process_page (TessBaseAPI* api, Pix* pix, int page_index, const char* filename, STRING* output) {
 				return api->ProcessPage(pix, page_index, filename, NULL, 0, output);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			ResultIterator* get_iterator (TessBaseAPI* api) {
@@ -206,31 +206,31 @@ module BaseAPI
 			char* get_utf8_text (TessBaseAPI* api) {
 				return api->GetUTF8Text();
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			char* get_box_text (TessBaseAPI* api, int page_number) {
 				return api->GetBoxText(page_number);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			char* get_unlv_text (TessBaseAPI* api) {
 				return api->GetUNLVText();
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			int mean_text_conf (TessBaseAPI* api) {
 				return api->MeanTextConf();
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			int* all_word_confidences (TessBaseAPI* api) {
 				return api->AllWordConfidences();
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			void clear (TessBaseAPI* api) {

--- a/lib/tesseract/c/iterator.rb
+++ b/lib/tesseract/c/iterator.rb
@@ -177,7 +177,7 @@ module Iterator
 				BoundingBox result;
 
 				it->BoundingBox(level, &result.left, &result.top, &result.right, &result.bottom);
-				
+
 				return result;
 			}
 		}
@@ -217,7 +217,7 @@ module Iterator
 		cpp.function %{
 			OrientationResult orientation (PageIterator* it) {
 				OrientationResult result;
-				
+
 				it->Orientation(&result.orientation, &result.writing_direction, &result.textline_order, &result.deskew_angle);
 
 				return result;
@@ -228,13 +228,13 @@ module Iterator
 			char* get_utf8_text (ResultIterator* it, PageIteratorLevel level) {
 				return it->GetUTF8Text(level);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			float confidence (ResultIterator* it, PageIteratorLevel level) {
 				return it->Confidence(level);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			FontAttributes word_font_attributes (ResultIterator* it) {

--- a/lib/tesseract/c/leptonica.rb
+++ b/lib/tesseract/c/leptonica.rb
@@ -45,25 +45,25 @@ module Leptonica
 			Pix* pix_read (const char* path) {
 				return pixRead(path);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			Pix* pix_read_fd (int fd) {
 				return pixReadStream(fdopen(fd, "rb"), 0);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			Pix* pix_read_mem (const l_uint8* data, size_t size) {
 				return pixReadMem(data, size);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			bool pix_write_mem (Pix* pix, uint8_t** data, size_t* size, Format format) {
 				return pixWriteMem(data, size, pix, format);
 			}
-		}
+		}, blocking: true
 
 		cpp.function %{
 			void pix_destroy (Pix* pix) {


### PR DESCRIPTION
Hi meh,

I was a little bit surprised just now, that github didn't like my pull request for ffi-inline - the patch was already there...

Here is the second part: Using the blocking flag for tesseract-ocr. Although I did some verification by looking into the tesseract sources and by doing parallel processing in a real application, I'm not fully sure, if I marked all the right methods.

Hope you like it. And thanks for your great work to integrate tesseract properly into ruby!
