### PR TITLE
The --psm option should be parsed as a number

### DIFF
--- a/bin/tesseract.rb
+++ b/bin/tesseract.rb
@@ -22,7 +22,7 @@ OptionParser.new do |o|
 	end
 
 	o.on '-p', '--psm MODE', 'page segmentation mode to use' do |value|
-		options[:psm] = value
+		options[:psm] = value.to_i
 	end
 
 	o.on '-u', '--unlv', 'output in UNLV format' do


### PR DESCRIPTION
or you will get:

```
 tesseract.rb --psm 1 foo.png
 /Users/raincole/.rvm/gems/ruby-1.9.3-p194/gems/ffi-1.1.5/lib/ffi/enum.rb:149:in `to_native': invalid enum value, :"8" (ArgumentError)
```
