### PR TITLE
Fix function name to read image from a stream

### DIFF
--- a/lib/tesseract/c/leptonica.rb
+++ b/lib/tesseract/c/leptonica.rb
@@ -48,7 +48,7 @@ module Leptonica
 		}, blocking: true
 
 		cpp.function %{
-			Pix* pix_read_fd (int fd) {
+			Pix* pix_read_stream (int fd) {
 				return pixReadStream(fdopen(fd, "rb"), 0);
 			}
 		}, blocking: true


### PR DESCRIPTION
When trying to read an image from a stream, I would receive this error:

`NoMethodError (undefined method 'pix_read_stream' for Tesseract::C::Leptonica:Module):`

This fixes it.
