### PR TITLE
Makes Tesseract.prefix= actually work.

### DIFF
--- a/lib/tesseract-ocr.rb
+++ b/lib/tesseract-ocr.rb
@@ -23,12 +23,11 @@
 #++
 
 module Tesseract
-	include self
-	def prefix
+	def self.prefix
 		ENV['TESSDATA_PREFIX']
 	end
 
-	def prefix= (path)
+	def self.prefix=(path)
 		ENV['TESSDATA_PREFIX'] = path
 	end
 end


### PR DESCRIPTION
It does not work as it stands in the released code - it needs to be a module-level method to be called this way.
