### PR TITLE
Fix class collision bug

### DIFF
--- a/lib/tesseract/engine/iterator.rb
+++ b/lib/tesseract/engine/iterator.rb
@@ -33,8 +33,6 @@ class Iterator
 	class Element
 		def self.for (level)
 			Iterator.const_get(level.capitalize)
-		rescue
-			self
 		end
 
 		def initialize (level, iterator)
@@ -90,6 +88,10 @@ class Iterator
 			@iterator.block_type
 		end
 	end
+
+	class Paragraph < Element; end
+
+	class Line < Element; end
 
 	class Word < Element
 		memoize

--- a/test/tesseract_spec.rb
+++ b/test/tesseract_spec.rb
@@ -2,6 +2,12 @@
 require 'rubygems'
 require 'tesseract'
 
+class Block; end
+class Paragraph; end
+class Line; end
+class Word; end
+class Symbol; end
+
 describe Tesseract::Engine do
 	let :engine do
 		Tesseract::Engine.new(language: :eng)


### PR DESCRIPTION
First just want to say thanks for your great library, which has made working with Tesseract much easier for me!

I ran into a small bug because I'm using this gem in a Rails project where I've got models named after document sections, including `Paragraph` and `Line`. I was baffled because when I tried to invoke those iterators, `engine.paragraphs_for` and `engine.lines_for`, I was seeing ActiveRecord errors coming back, which made no sense.

I traced this to the iterator API, where it falls back on the `Element` class if the constant (`Paragraph` or `Line`) isn't found. In my case, `Paragraph` and `Line` _were_ found—it's just that they were my ActiveRecord models.

This is easily fixed by including those classes explicitly. With this simple modification all is well in my Rails project again. However, I think a better long-term solution might be to get rid of the `const_get`/`rescue` scheme altogether.

Let me know if you want me to change anything here.
